### PR TITLE
Fix typo in GNUmakefile.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ LIBRARY_NAME = MPWTest
 
 
 MPWTest_OBJC_FILES = \
-	MPSTestSuite.m MPWLoggingTester.m MPWTestCase.m \
+	MPWTestSuite.m MPWLoggingTester.m MPWTestCase.m \
 	MPWTestResults.m NSBundleClassEnumeration.m NSObjectTestingSupport.m \
 
 


### PR DESCRIPTION
Fix typo found on the `[objc retain];` stream with @iamleeg